### PR TITLE
fix(vimeo.js): assign empty object when no params pass to upload & replace method

### DIFF
--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -429,7 +429,7 @@ Vimeo.prototype.upload = function (
     errorCallback = progressCallback
     progressCallback = completeCallback
     completeCallback = params
-    params = undefined
+    params = {} 
   }
 
   try {
@@ -509,7 +509,7 @@ Vimeo.prototype.replace = function (
     errorCallback = progressCallback
     progressCallback = completeCallback
     completeCallback = params
-    params = undefined
+    params = {} 
   }
 
   try {


### PR DESCRIPTION
As title.

Assign empty object when no params pass to upload & replace method

However, I only test `upload` method and it works.
@erunion Do you mind checking this?

related issue:
https://github.com/vimeo/vimeo.js/issues/65