### PR TITLE
Aborting retry after first error

### DIFF
--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -135,7 +135,8 @@ Vimeo.prototype.request = function (options, callback) {
   }
 
   req.on('error', function (e) {
-    callback(e)
+    callback(e);
+    req.abort ();
   })
 
   req.end()


### PR DESCRIPTION
Fixing bug related to issue #130 , now the req.abort call prevents the request to be sent once again after the first error is found.