### PR TITLE
Return error to callback

### DIFF
--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -171,7 +171,7 @@ Vimeo.prototype._handleRequest = function (callback) {
         try {
           var body = buffer.length ? JSON.parse(buffer) : {}
         } catch (e) {
-          return callback(buffer, buffer, res.statusCode, res.headers)
+          return callback(e, buffer, res.statusCode, res.headers)
         }
 
         callback(null, body, res.statusCode, res.headers)


### PR DESCRIPTION
Thanks for your work on vimeo.js!

The first argument of the callback should be an error, not a buffer.

cc @aaronm67 