### PR TITLE
supports text plain content type in `vimeo.request`

### DIFF
--- a/example/auth_example.js
+++ b/example/auth_example.js
@@ -40,7 +40,7 @@ var stateData = {
 // Here we have to build the Vimeo library using the configured `client_id` and `client_secret`. We
 // do not need an access token here because we will generate one. If we already knew our access
 // token, we can provide it as the third parameter.
-var lib = new Vimeo(config.client_id, config.client_secret)
+var lib = new Vimeo(config.client_id, config.client_secret, config.access_token)
 
 var scopes = ['public', 'private', 'edit', 'interact']
 var callbackUrl = 'http://localhost:8080/oauth_callback'

--- a/example/example.js
+++ b/example/example.js
@@ -35,7 +35,7 @@ try {
 //
 // For the request we make below (/channels) the access token can be a client access token instead
 // of a user access token.
-var lib = new Vimeo(config.client_id, config.client_secret)
+var lib = new Vimeo(config.client_id, config.client_secret, config.access_token)
 
 if (config.access_token) {
   lib.setAccessToken(config.access_token)

--- a/example/search.js
+++ b/example/search.js
@@ -59,7 +59,7 @@ function makeRequest (lib) {
   })
 }
 
-var lib = new Vimeo(config.client_id, config.client_secret)
+var lib = new Vimeo(config.client_id, config.client_secret, config.access_token)
 
 if (config.access_token) {
   lib.setAccessToken(config.access_token)

--- a/example/upload_texttrack.js
+++ b/example/upload_texttrack.js
@@ -1,0 +1,103 @@
+'use strict'
+
+/**
+ *   Copyright 2023 Vimeo
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+const fs = require('fs')
+const Vimeo = require('../index').Vimeo
+let config
+
+try {
+  config = require('./config.json')
+} catch (error) {
+  console.error('ERROR: For this example to run properly you must create an API app at ' +
+    'https://developer.vimeo.com/apps/new and set your callback url to ' +
+    '`http://localhost:8080/oauth_callback`.')
+  console.error('ERROR: Once you have your app, make a copy of `config.json.example` named ' +
+    '`config.json` and add your client ID, client secret and access token.')
+  process.exit()
+}
+const lib = new Vimeo(config.client_id, config.client_secret, config.access_token)
+
+// Documentation: https://developer.vimeo.com/api/upload/texttracks
+
+const getUploadLink = (path, token, type = 'captions', language = 'en', name = '') => {
+  return new Promise((resolve, reject) => {
+    lib.request(
+      {
+        hostname: 'api.vimeo.com',
+        path,
+        headers: {
+          Authorization: 'bearer ' + token,
+          'Content-Type': 'application/json'
+        },
+        method: 'POST',
+        query: {
+          type,
+          language
+        }
+      },
+      (err, body, statusCode, headers) => {
+        if (err) {
+          reject(err)
+        }
+        resolve({ body, statusCode, headers })
+      }
+    )
+  })
+}
+
+const uploadTextTrack = (textTrackUrl, token, filePath) => {
+  return new Promise((resolve, reject) => {
+    const vttSubs = fs.readFileSync(
+      filePath,
+      'utf-8'
+    )
+
+    lib.request(
+      {
+        hostname: 'captions.cloud.vimeo.com',
+        path: textTrackUrl.replace('https://captions.cloud.vimeo.com/', ''),
+        headers: {
+          Authorization: 'bearer ' + token,
+          'Content-Type': 'text/plain' // important!
+        },
+        method: 'PUT',
+        body: vttSubs
+      },
+      (err, body, statusCode, headers) => {
+        if (err) {
+          reject(err)
+        }
+        resolve({ body, statusCode, headers })
+      }
+    )
+  })
+}
+
+const uploadTextTrackCycle = async () => {
+  const token = config.access_token
+  const textTrackUri = '/videos/[video id]/texttracks'
+  const vttPath = 'path'
+
+  const uploadLink = await getUploadLink(textTrackUri, token).catch(e => console.log('Error: ', e))
+  console.log(uploadLink.body.link)
+
+  const res = await uploadTextTrack(uploadLink.body.link, token, vttPath).catch(e => console.log('Error: ', e))
+  console.log(res.statusCode)
+}
+
+uploadTextTrackCycle()

--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -117,8 +117,10 @@ Vimeo.prototype.request = function (options, callback) {
   if (['POST', 'PATCH', 'PUT', 'DELETE'].indexOf(requestOptions.method) !== -1) {
     if (requestOptions.headers['Content-Type'] === 'application/json') {
       requestOptions.body = JSON.stringify(options.query)
-    } else {
+    } else if (requestOptions.headers['Content-Type'] === 'application/x-www-form-urlencoded') {
       requestOptions.body = qsModule.stringify(options.query)
+    } else {
+      requestOptions.body = options.body
     }
 
     if (requestOptions.body) {

--- a/test/lib/vimeo_test.js
+++ b/test/lib/vimeo_test.js
@@ -97,9 +97,9 @@ describe('Vimeo.generateClientCredentials', () => {
   describe('callback is called with the expected parameters', () => {
     it('request returns an error', () => {
       const error = 'Request Error'
-      const body = { 'body': 'body' }
-      const status = { 'status': 'status' }
-      const headers = { 'headers': 'headers' }
+      const body = { body: 'body' }
+      const status = { status: 'status' }
+      const headers = { headers: 'headers' }
       const mockRequest = sinon.fake.yields(error, body, status, headers)
       sinon.replace(vimeo, 'request', mockRequest)
       const mockCallback = sinon.fake()
@@ -110,9 +110,9 @@ describe('Vimeo.generateClientCredentials', () => {
     })
 
     it('request is successful', () => {
-      const body = { 'body': 'body' }
-      const status = { 'status': 'status' }
-      const headers = { 'headers': 'headers' }
+      const body = { body: 'body' }
+      const status = { status: 'status' }
+      const headers = { headers: 'headers' }
       const mockRequest = sinon.fake.yields(null, body, status, headers)
       sinon.replace(vimeo, 'request', mockRequest)
       const mockCallback = sinon.fake()
@@ -159,9 +159,9 @@ describe('Vimeo.accessToken', () => {
   describe('callback is called with the expected parameters', () => {
     it('request returns an error', () => {
       const error = 'Request Error'
-      const body = { 'body': 'body' }
-      const status = { 'status': 'status' }
-      const headers = { 'headers': 'headers' }
+      const body = { body: 'body' }
+      const status = { status: 'status' }
+      const headers = { headers: 'headers' }
       const mockRequest = sinon.fake.yields(error, body, status, headers)
       sinon.replace(vimeo, 'request', mockRequest)
       const mockCallback = sinon.fake()
@@ -172,9 +172,9 @@ describe('Vimeo.accessToken', () => {
     })
 
     it('request is successful', () => {
-      const body = { 'body': 'body' }
-      const status = { 'status': 'status' }
-      const headers = { 'headers': 'headers' }
+      const body = { body: 'body' }
+      const status = { status: 'status' }
+      const headers = { headers: 'headers' }
       const mockRequest = sinon.fake.yields(null, body, status, headers)
       sinon.replace(vimeo, 'request', mockRequest)
       const mockCallback = sinon.fake()
@@ -286,11 +286,18 @@ describe('Vimeo.request', () => {
       sinon.assert.calledWith(mockHttpsRequest, sinon.match({ body: '{"a":"b"}' }))
     })
 
-    it('sends body as string if content type is not application/json', () => {
-      vimeo.request({ method: 'POST', path: '/path', query: { a: 'b' }, headers: { 'Content-Type': 'not-application/json' } }, () => { })
+    it('sends form data as string if content type is application/x-www-form-urlencoded', () => {
+      vimeo.request({ method: 'POST', path: '/path', query: { a: 'b', c: 'd' }, headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }, () => { })
 
       sinon.assert.calledOnce(mockHttpsRequest)
-      sinon.assert.calledWith(mockHttpsRequest, sinon.match({ body: 'a=b' }))
+      sinon.assert.calledWith(mockHttpsRequest, sinon.match({ body: 'a=b&c=d' }))
+    })
+
+    it('sends body as it is if content type is not application/x-www-form-urlencoded nor application/json', () => {
+      vimeo.request({ method: 'POST', path: '/path', body: 'text', headers: { 'Content-Type': 'text/plain' } }, () => { })
+
+      sinon.assert.calledOnce(mockHttpsRequest)
+      sinon.assert.calledWith(mockHttpsRequest, sinon.match({ body: 'text' }))
     })
 
     it('sets the correct body Content-Length', () => {
@@ -348,7 +355,7 @@ describe('Vimeo._handleRequest', () => {
     mockRes = new events.EventEmitter()
     mockRes.on = sinon.fake(mockRes.on)
     mockRes.setEncoding = sinon.fake()
-    mockRes.headers = { 'headers': 'value' }
+    mockRes.headers = { headers: 'value' }
   })
 
   afterEach(() => {
@@ -398,7 +405,7 @@ describe('Vimeo._handleRequest', () => {
     mockRes.emit('readable')
     mockRes.emit('end')
     sinon.assert.calledOnce(mockCallback)
-    sinon.assert.calledWith(mockCallback, '{"bad": "json"', '{"bad": "json"', mockRes.statusCode, mockRes.headers)
+    sinon.assert.calledWith(mockCallback, sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Unexpected end of JSON input')), '{"bad": "json"', mockRes.statusCode, mockRes.headers)
   })
 
   it('calls callback the body parsed as JSON', () => {


### PR DESCRIPTION
## Issue

For content passed to `vimeo.request` using the `body` key, when its type is not `application/json`, `qsModule.stringify(options.query)` is used to stringify `query` object rather than using the `body` parameter. This ensures content-type `text/plain` is sent as plaintext when specified for text track upload

## What this PR does
- This PR ensures that if content type is not `application/x-www-form-urlencoded` nor `application/json`, `body` value passed in the request options is used as the content body
- Adds an example for text track upload
- Fixes some minor issues with the examples and test cases

## Testing
- Adds unit tests for the new changes and tested with the text track example