### PR TITLE
Adds the Promise support for the Vimeo.accessToken method

### DIFF
--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -46,7 +46,7 @@ const authEndpoints = module.exports.authEndpoints = {
  *
  * @param {string} clientId     OAuth 2 Client Identifier
  * @param {string} clientSecret OAuth 2 Client Secret
- * @param {string} accessToken  OAuth 2 Optional pre-authorized access token
+ * @param {string} [accessToken]  OAuth 2 Optional pre-authorized access token
  */
 const Vimeo = module.exports.Vimeo = function Vimeo (clientId, clientSecret, accessToken) {
   this._clientId = clientId
@@ -92,7 +92,7 @@ Vimeo.prototype._accessToken = null
  *
  * @param {string|Object} options   String path (default GET), or object with `method`, path`,
  *                                  `host`, `port`, `query`, `body`, or `headers`.
- * @param {Function|null} callback  (optional) Called when complete, `function (err, json)`. If not passed in, a Promise will be returned.
+ * @param {Function} [callback]     (optional) Called when complete, `function (err, json)`. If not passed in, a Promise will be returned.
  */
 Vimeo.prototype.request = function (options, callback) {
   let client = null
@@ -174,7 +174,7 @@ Vimeo.prototype.request = function (options, callback) {
  * Creates the standard request handler for http requests
  *
  * @param  {Function} callback
- * @param  {Function} reject (optional) used when called inside a Promise
+ * @param  {Function} [reject] (optional) used when called inside a Promise
  * @return {Function}
  */
 Vimeo.prototype._handleRequest = function (callback, reject) {
@@ -325,7 +325,7 @@ Vimeo.prototype.setAccessToken = function (accessToken) {
  * @param {string}   code         The code provided on your `redirectUri`.
  * @param {string}   redirectUri  The exact `redirectUri` provided to `buildAuthorizationEndpoint`
  *                                and configured in your API app settings.
- * @param {Function|null} fn      (optional) Callback to execute on completion. If not passed in, a Promise will be returned.
+ * @param {Function} [fn]         (optional) Callback to execute on completion. If not passed in, a Promise will be returned.
  */
 Vimeo.prototype.accessToken = function (code, redirectUri, fn) {
   const options = {

--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -178,6 +178,7 @@ Vimeo.prototype.request = function (options, callback) {
  * @return {Function}
  */
 Vimeo.prototype._handleRequest = function (callback, reject) {
+  const isPromise = reject !== undefined
   reject = reject || callback
 
   return function (res) {
@@ -203,11 +204,13 @@ Vimeo.prototype._handleRequest = function (callback, reject) {
       res.on('end', function () {
         try {
           body = buffer.length ? JSON.parse(buffer) : {}
-        } catch (e) {
-          return reject(e, buffer, res.statusCode, res.headers)
-        }
 
-        callback(null, body, res.statusCode, res.headers)
+          isPromise
+            ? callback(body)
+            : callback(null, body, res.statusCode, res.headers)
+        } catch (err) {
+          return reject(err, buffer, res.statusCode, res.headers)
+        }
       })
     }
   }
@@ -322,7 +325,7 @@ Vimeo.prototype.setAccessToken = function (accessToken) {
  * @param {string}   code         The code provided on your `redirectUri`.
  * @param {string}   redirectUri  The exact `redirectUri` provided to `buildAuthorizationEndpoint`
  *                                and configured in your API app settings.
- * @param {Function} fn           Callback to execute on completion.
+ * @param {Function|null} fn      (optional) Callback to execute on completion. If not passed in, a Promise will be returned.
  */
 Vimeo.prototype.accessToken = function (code, redirectUri, fn) {
   const options = {
@@ -339,13 +342,23 @@ Vimeo.prototype.accessToken = function (code, redirectUri, fn) {
     }
   }
 
-  this.request(options, function (err, body, status, headers) {
-    if (err) {
-      return fn(err, null, status, headers)
-    } else {
-      fn(null, body, status, headers)
-    }
-  })
+  if (fn === undefined) {
+    return new Promise((resolve, reject) => {
+      this.request(options).then((res) => {
+        resolve(res)
+      }).catch((err) => {
+        reject(err)
+      })
+    })
+  } else {
+    this.request(options, function (err, body, status, headers) {
+      if (err) {
+        return fn(err, null, status, headers)
+      } else {
+        fn(null, body, status, headers)
+      }
+    })
+  }
 }
 
 /**

--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -343,13 +343,7 @@ Vimeo.prototype.accessToken = function (code, redirectUri, fn) {
   }
 
   if (fn === undefined) {
-    return new Promise((resolve, reject) => {
-      this.request(options).then((res) => {
-        resolve(res)
-      }).catch((err) => {
-        reject(err)
-      })
-    })
+    return this.request(options)
   } else {
     this.request(options, function (err, body, status, headers) {
       if (err) {

--- a/test/lib/vimeo_test.js
+++ b/test/lib/vimeo_test.js
@@ -166,6 +166,19 @@ describe('Vimeo.accessToken', () => {
       sinon.assert.calledOnce(mockCallback)
       sinon.assert.calledWith(mockCallback, error, null, status, headers)
     })
+
+    it('request is successful', () => {
+      const body = { body: 'body' }
+      const status = { status: 'status' }
+      const headers = { headers: 'headers' }
+      const mockRequest = sinon.fake.yields(null, body, status, headers)
+      sinon.replace(vimeo, 'request', mockRequest)
+      const mockCallback = sinon.fake()
+
+      vimeo.accessToken(CODE, REDIRECT_URI, mockCallback)
+      sinon.assert.calledOnce(mockCallback)
+      sinon.assert.calledWith(mockCallback, null, body, status, headers)
+    })
   })
 
   describe('request and response are expected for the Promise implementation', () => {
@@ -564,11 +577,7 @@ describe('Vimeo._handleRequest', () => {
     mockRes.emit('readable')
     mockRes.emit('end')
     sinon.assert.calledOnce(mockCallback)
-    sinon.assert.calledWith(mockCallback,
-      sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Unexpected end of JSON input')),
-      '{"bad": "json"',
-      mockRes.statusCode,
-      mockRes.headers)
+    sinon.assert.calledWith(mockCallback, sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Unexpected end of JSON input')))
   })
 
   it('calls callback the body parsed as JSON', () => {
@@ -629,7 +638,11 @@ describe('Vimeo._handleRequest', () => {
       mockRes.emit('readable')
       mockRes.emit('end')
       sinon.assert.calledOnce(mockReject)
-      sinon.assert.calledWith(mockReject, sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Unexpected end of JSON input')))
+      sinon.assert.calledWith(mockReject,
+        sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Unexpected end of JSON input')),
+        '{"bad": "json"',
+        mockRes.statusCode,
+        mockRes.headers)
     })
 
     it('calls the first fn if the body parsed as JSON', () => {

--- a/test/lib/vimeo_test.js
+++ b/test/lib/vimeo_test.js
@@ -201,16 +201,12 @@ describe('Vimeo.accessToken', () => {
     })
 
     it('returns the expected response when the request is successful', async () => {
-      const resObject = {
-        body: 'body',
-        status: 'status',
-        headers: 'headers'
-      }
+      const body = 'body'
 
-      sinon.stub(vimeo, 'request').resolves({ ...resObject, error: null, hi: 'test' })
+      sinon.stub(vimeo, 'request').resolves(body)
 
       await vimeo.accessToken(CODE, REDIRECT_URI).then((res) => {
-        sinon.assert.match(res, resObject)
+        sinon.assert.match(res, body)
       })
     })
   })
@@ -469,7 +465,7 @@ describe('Vimeo.request', () => {
       expect(req).to.equal('Success.')
     })
 
-    it('returns the correct response when the Promise is rejected', async () => {
+    it('returns the error object when the Promise is rejected', async () => {
       handleRequestStub.resetBehavior()
 
       const err = new Error('Request Error')
@@ -568,7 +564,11 @@ describe('Vimeo._handleRequest', () => {
     mockRes.emit('readable')
     mockRes.emit('end')
     sinon.assert.calledOnce(mockCallback)
-    sinon.assert.calledWith(mockCallback, sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Unexpected end of JSON input')), '{"bad": "json"', mockRes.statusCode, mockRes.headers)
+    sinon.assert.calledWith(mockCallback,
+      sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Unexpected end of JSON input')),
+      '{"bad": "json"',
+      mockRes.statusCode,
+      mockRes.headers)
   })
 
   it('calls callback the body parsed as JSON', () => {


### PR DESCRIPTION
- updates the request promise to only return the body or error object since `resolve` and `reject` only accept one argument and they already indicate if the request is fulfilled or rejected
- adds the Promise support for the `accessToken` method and its corresponding tests 