### PR TITLE
adds the Promise API for the generateClientCredentials method

### DIFF
--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -344,15 +344,15 @@ Vimeo.prototype.accessToken = function (code, redirectUri, fn) {
 
   if (fn === undefined) {
     return this.request(options)
-  } else {
-    this.request(options, function (err, body, status, headers) {
-      if (err) {
-        return fn(err, null, status, headers)
-      } else {
-        fn(null, body, status, headers)
-      }
-    })
   }
+
+  this.request(options, function (err, body, status, headers) {
+    if (err) {
+      return fn(err, null, status, headers)
+    } else {
+      fn(null, body, status, headers)
+    }
+  })
 }
 
 /**
@@ -405,10 +405,10 @@ Vimeo.prototype.buildAuthorizationEndpoint = function (redirectUri, scope, state
  * Generates an unauthenticated access token. This is necessary to make unauthenticated requests
  *
  * @param  {string|string[]} scope  An array of scopes. See https://developer.vimeo.com/api/authentication#scopes
- *                          for more.
- * @param  {Function} fn    A function that is called when the request is complete. If an error
- *                          occured the first parameter will be that error, otherwise the first
- *                          parameter will be null.
+ *                                  for more.
+ * @param  {Function}        [fn]   (optional) A function that is called when the request is complete. If an error
+ *                                  occured the first parameter will be that error, otherwise the first
+ *                                  parameter will be null. If not passed in, a Promise will be returned.
  */
 Vimeo.prototype.generateClientCredentials = function (scope, fn) {
   const query = {
@@ -425,7 +425,7 @@ Vimeo.prototype.generateClientCredentials = function (scope, fn) {
     query.scope = 'public'
   }
 
-  this.request({
+  const options = {
     method: 'POST',
     hostname: module.exports.request_defaults.hostname,
     path: authEndpoints.clientCredentials,
@@ -433,7 +433,13 @@ Vimeo.prototype.generateClientCredentials = function (scope, fn) {
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded'
     }
-  }, function (err, body, status, headers) {
+  }
+
+  if (fn === undefined) {
+    return this.request(options)
+  }
+
+  this.request(options, function (err, body, status, headers) {
     if (err) {
       return fn(err, null, status, headers)
     } else {


### PR DESCRIPTION
- returns a Promise for the `generateClientCredentials` method when a callback function is not provided
- adds tests