### PR TITLE
Adds Promise support for `Vimeo.upload` method

### DIFF
--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -462,7 +462,7 @@ Vimeo.prototype.generateClientCredentials = function (scope, fn) {
  *    If an object is not provided, default upload params are used.
  *
  * -  completeCallback and errorCallback (optional)
- *    If not passed in, a Promise will be returned.
+ *    If neither passed in, a Promise will be returned.
  *    Ex. vimeo.upload(file, progressCallback) or vimeo.upload(file, params, progressCallback)
  *
  * @param {string}    file                Path to the file you wish to upload.

--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -459,7 +459,7 @@ Vimeo.prototype.generateClientCredentials = function (scope, fn) {
  * .upload( file [, params] [, completeCallback], progressCallback [, errorCallback])
  *
  * -  params (optional)
- *    If an object is not provided, we will use the default upload params.
+ *    If an object is not provided, default upload params are used.
  *
  * -  completeCallback and errorCallback (optional)
  *    If not passed in, a Promise will be returned.
@@ -533,9 +533,7 @@ Vimeo.prototype.upload = function (
 
   if (isPromise) {
     return new Promise((resolve, reject) => {
-      this.request(options).catch(err => {
-        reject(new Error('Unable to initiate an upload. [' + err.message + ']'))
-      }).then(attempt => {
+      this.request(options).then(attempt => {
         _self._performTusUpload(
           file,
           fileSize,
@@ -544,6 +542,8 @@ Vimeo.prototype.upload = function (
           progressCallback,
           reject
         )
+      }).catch(err => {
+        reject(new Error('Unable to initiate an upload. [' + err.message + ']'))
       })
     })
   }
@@ -667,8 +667,6 @@ Vimeo.prototype._performTusUpload = function (
   errorCallback
 ) {
   let fileUpload = file
-
-  console.log('_performTusUpload')
 
   if (typeof file === 'string') {
     fileUpload = fs.createReadStream(file)

--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -456,13 +456,22 @@ Vimeo.prototype.generateClientCredentials = function (scope, fn) {
  *
  * https://developer.vimeo.com/api/reference/videos#upload_video
  *
- * @param {string}    file              Path to the file you wish to upload.
- * @param {Object=}   params            Parameters to send when creating a new video (name,
- *                                      privacy restrictions, etc.). See the API documentation for
- *                                      supported parameters.
- * @param {Function}  completeCallback  Callback to be executed when the upload completes.
- * @param {Function}  progressCallback  Callback to be executed when upload progress is updated.
- * @param {Function}  errorCallback     Callback to be executed when the upload returns an error.
+ * .upload( file [, params] [, completeCallback], progressCallback [, errorCallback])
+ *
+ * -  params (optional)
+ *    If an object is not provided, we will use the default upload params.
+ *
+ * -  completeCallback and errorCallback (optional)
+ *    If not passed in, a Promise will be returned.
+ *    Ex. vimeo.upload(file, progressCallback) or vimeo.upload(file, params, progressCallback)
+ *
+ * @param {string}    file                Path to the file you wish to upload.
+ * @param {Object=}   [params]            (optional) Parameters to send when creating a new video (name,
+ *                                        privacy restrictions, etc.). See the API documentation for
+ *                                        supported parameters.
+ * @param {Function}  [completeCallback]  (optional) Callback to be executed when the upload completes.
+ * @param {Function}  progressCallback    Callback to be executed when upload progress is updated.
+ * @param {Function}  [errorCallback]     (optional) Callback to be executed when the upload returns an error.
  */
 Vimeo.prototype.upload = function (
   file,
@@ -481,14 +490,28 @@ Vimeo.prototype.upload = function (
     params = {}
   }
 
+  const isPromise = progressCallback === undefined && errorCallback === undefined
+
+  if (isPromise) {
+    progressCallback = completeCallback
+  }
+
   if (typeof file === 'string') {
     try {
       fileSize = fs.statSync(file).size
     } catch (e) {
+      if (isPromise) {
+        return new Promise((resolve, reject) => reject(e))
+      }
+
       return errorCallback('Unable to locate file to upload.')
     }
   } else {
-    fileSize = file.size
+    const error = new Error('Please pass in a valid file path.')
+    if (isPromise) {
+      return new Promise((resolve, reject) => reject(error))
+    }
+    return errorCallback(error)
   }
 
   // Ignore any specified upload approach and size.
@@ -508,8 +531,25 @@ Vimeo.prototype.upload = function (
     query: params
   }
 
+  if (isPromise) {
+    return new Promise((resolve, reject) => {
+      this.request(options).catch(err => {
+        reject(new Error('Unable to initiate an upload. [' + err.message + ']'))
+      }).then(attempt => {
+        _self._performTusUpload(
+          file,
+          fileSize,
+          attempt,
+          resolve,
+          progressCallback,
+          reject
+        )
+      })
+    })
+  }
+
   // Use JSON filtering so we only receive the data that we need to make an upload happen.
-  this.request(options, function (err, attempt, status) {
+  this.request(options, function (err, attempt) {
     if (err) {
       return errorCallback('Unable to initiate an upload. [' + err + ']')
     }
@@ -627,6 +667,8 @@ Vimeo.prototype._performTusUpload = function (
   errorCallback
 ) {
   let fileUpload = file
+
+  console.log('_performTusUpload')
 
   if (typeof file === 'string') {
     fileUpload = fs.createReadStream(file)

--- a/test/lib/vimeo_promise_test.js
+++ b/test/lib/vimeo_promise_test.js
@@ -1,0 +1,130 @@
+/* eslint-env mocha */
+'use strict'
+
+const Vimeo = require('../../lib/vimeo').Vimeo
+const fs = require('fs') // Needed for mocking
+const sinon = require('sinon')
+
+afterEach(() => {
+  sinon.restore()
+})
+
+describe('Vimeo.upload using the Promise API', () => {
+  const FILE_NAME = '/real/file'
+  const FILE_SIZE = 24601
+  const vimeo = new Vimeo('id', 'secret', 'token')
+  const attempt = { upload: { upload_link: 'body' }, uri: 'uri' }
+  let requestStub
+  let mockProgressCallback
+
+  beforeEach(() => {
+    requestStub = sinon.stub(vimeo, 'request').resolves(attempt)
+    mockProgressCallback = sinon.fake()
+  })
+
+  it('throws an error if the file is inexistant', async () => {
+    const error = new Error('File Error')
+    const errFs = sinon.fake.throws(error)
+    sinon.replace(fs, 'statSync', errFs)
+
+    const vimeo = new Vimeo('id', 'secret', 'token')
+    await vimeo.upload(FILE_NAME, {}).catch(err => {
+      sinon.assert.match(err, error)
+    })
+  })
+
+  it('throws an error if the file parameter is an object', async () => {
+    const fileObject = { size: 123 }
+    await vimeo.upload(fileObject, {}).catch(err => sinon.assert.match(err, sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Please pass in a valid file path.'))))
+  })
+
+  describe('file exists', () => {
+    let mockTusUpload
+    beforeEach(() => {
+      const mockFs = sinon.fake.returns({ size: FILE_SIZE })
+      mockTusUpload = sinon.stub(vimeo, '_performTusUpload').callsFake((files, size, attempt, completeCallback, progressCallback, errorCallback) => completeCallback('uri'))
+      sinon.replace(fs, 'statSync', mockFs)
+    })
+
+    describe('always uses `tus` to upload', () => {
+      it('if upload.approach is not specified', async () => {
+        await vimeo.upload(FILE_NAME, {})
+
+        sinon.assert.calledOnce(requestStub)
+        const expectedPayload = {
+          query: { upload: { approach: 'tus' } }
+        }
+        sinon.assert.calledWith(requestStub, sinon.match(expectedPayload))
+      })
+
+      it('if upload.approach is not tus', async () => {
+        await vimeo.upload(FILE_NAME, { upload: { approach: 'not-tus' } })
+
+        sinon.assert.calledOnce(requestStub)
+        const expectedPayload = {
+          query: { upload: { approach: 'tus' } }
+        }
+        sinon.assert.calledWith(requestStub, sinon.match(expectedPayload))
+      })
+    })
+
+    it('request is called with the expected parameters', async () => {
+      await vimeo.upload(FILE_NAME, {})
+
+      sinon.assert.calledOnce(requestStub)
+      const expectedPayload = {
+        method: 'POST',
+        path: '/me/videos?fields=uri,name,upload',
+        query: { upload: { approach: 'tus', size: FILE_SIZE } }
+      }
+      sinon.assert.calledWith(requestStub, expectedPayload)
+    })
+
+    it('calls the errorCallback if request returned an error', async () => {
+      const error = new Error('Request Error')
+      requestStub.rejects(error)
+
+      await vimeo.upload(FILE_NAME, {}).catch(err => sinon.assert.match(err, sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Unable to initiate an upload. [Request Error]'))))
+    })
+
+    it('calls _performTusUpload with the expected parameters', async () => {
+      await vimeo.upload(FILE_NAME, {}, mockProgressCallback)
+
+      sinon.assert.calledOnce(mockTusUpload)
+      sinon.assert.calledWith(mockTusUpload, FILE_NAME, FILE_SIZE, attempt, sinon.match.typeOf('function'), mockProgressCallback, sinon.match.typeOf('function'))
+    })
+
+    it('shifts callbacks if param is not passed to the function', async () => {
+      await vimeo.upload(FILE_NAME, mockProgressCallback)
+
+      sinon.assert.calledOnce(mockTusUpload)
+      sinon.assert.calledWith(mockTusUpload, FILE_NAME, FILE_SIZE, attempt, sinon.match.typeOf('function'), mockProgressCallback, sinon.match.typeOf('function'))
+    })
+
+    it('returns uri when upload completes', async () => {
+      await vimeo.upload(FILE_NAME, mockProgressCallback).then((res) => sinon.assert.match(res, 'uri'))
+    })
+
+    it('returns error when upload fails', async () => {
+      const error = new Error('Upload Error')
+      mockTusUpload.resetBehavior()
+      mockTusUpload.callsFake((files, size, attempt, completeCallback, progressCallback, errorCallback) => errorCallback(error))
+      await vimeo.upload(FILE_NAME, mockProgressCallback).catch((err) => {
+        sinon.assert.match(err, error)
+      })
+    })
+
+    it('sents progress through the progressCallback during upload', async () => {
+      mockTusUpload.resetBehavior()
+      mockTusUpload.callsFake((files, size, attempt, completeCallback, progressCallback, errorCallback) => {
+        progressCallback('bytesUploaded', 'bytesTotal')
+        progressCallback('bytesUploaded2', 'bytesTotal2')
+        completeCallback()
+      })
+      await vimeo.upload(FILE_NAME, mockProgressCallback)
+      sinon.assert.calledTwice(mockProgressCallback)
+      sinon.assert.calledWith(mockProgressCallback.getCall(0), 'bytesUploaded', 'bytesTotal')
+      sinon.assert.calledWith(mockProgressCallback.getCall(1), 'bytesUploaded2', 'bytesTotal2')
+    })
+  })
+})

--- a/test/lib/vimeo_promise_test.js
+++ b/test/lib/vimeo_promise_test.js
@@ -42,7 +42,7 @@ describe('Vimeo.upload using the Promise API', () => {
     let mockTusUpload
     beforeEach(() => {
       const mockFs = sinon.fake.returns({ size: FILE_SIZE })
-      mockTusUpload = sinon.stub(vimeo, '_performTusUpload').callsFake((files, size, attempt, completeCallback, progressCallback, errorCallback) => completeCallback('uri'))
+      mockTusUpload = sinon.stub(vimeo, '_performTusUpload').callsFake((files, size, attempt, onComplete, onProgress, onError) => onComplete('uri'))
       sinon.replace(fs, 'statSync', mockFs)
     })
 
@@ -80,7 +80,7 @@ describe('Vimeo.upload using the Promise API', () => {
       sinon.assert.calledWith(requestStub, expectedPayload)
     })
 
-    it('calls the errorCallback if request returned an error', async () => {
+    it('calls the onError if request returned an error', async () => {
       const error = new Error('Request Error')
       requestStub.rejects(error)
 
@@ -108,7 +108,7 @@ describe('Vimeo.upload using the Promise API', () => {
     it('returns error when upload fails', async () => {
       const error = new Error('Upload Error')
       mockTusUpload.resetBehavior()
-      mockTusUpload.callsFake((files, size, attempt, completeCallback, progressCallback, errorCallback) => errorCallback(error))
+      mockTusUpload.callsFake((files, size, attempt, onComplete, onProgress, onError) => onError(error))
       await vimeo.upload(FILE_NAME, mockProgressCallback).catch((err) => {
         sinon.assert.match(err, error)
       })
@@ -116,10 +116,10 @@ describe('Vimeo.upload using the Promise API', () => {
 
     it('sents progress through the progressCallback during upload', async () => {
       mockTusUpload.resetBehavior()
-      mockTusUpload.callsFake((files, size, attempt, completeCallback, progressCallback, errorCallback) => {
-        progressCallback('bytesUploaded', 'bytesTotal')
-        progressCallback('bytesUploaded2', 'bytesTotal2')
-        completeCallback()
+      mockTusUpload.callsFake((files, size, attempt, onComplete, onProgress, onError) => {
+        onProgress('bytesUploaded', 'bytesTotal')
+        onProgress('bytesUploaded2', 'bytesTotal2')
+        onComplete()
       })
       await vimeo.upload(FILE_NAME, mockProgressCallback)
       sinon.assert.calledTwice(mockProgressCallback)

--- a/test/lib/vimeo_test.js
+++ b/test/lib/vimeo_test.js
@@ -168,8 +168,8 @@ describe('Vimeo.generateClientCredentials', () => {
 
   describe('a Promise is returned with the expected response or error when the callback is not passed in', () => {
     it('request returns an error', async () => {
-      const error = 'Request Error'
-      sinon.stub(vimeo, 'request').resolves(error)
+      const error = new Error('Request Error')
+      sinon.stub(vimeo, 'request').rejects(error)
 
       await vimeo.generateClientCredentials('scope').catch(err => sinon.assert.match(err, error))
     })

--- a/test/lib/vimeo_test.js
+++ b/test/lib/vimeo_test.js
@@ -744,24 +744,14 @@ describe('Vimeo.upload', () => {
     sinon.assert.calledWith(mockErrorCallback, 'Unable to locate file to upload.')
   })
 
-  describe('file parameter is an object', () => {
-    it('request is called with the expected parameters', () => {
-      const mockRequest = sinon.fake()
-      sinon.replace(vimeo, 'request', mockRequest)
+  it('calls the errorCallback if the file parameter is an object', () => {
+    const fileObject = {
+      size: FILE_SIZE
+    }
+    vimeo.upload(fileObject, {}, mockCompleteCallback, mockProgressCallback, mockErrorCallback)
 
-      const fileObject = {
-        size: FILE_SIZE
-      }
-      vimeo.upload(fileObject, {}, mockCompleteCallback, mockProgressCallback, mockErrorCallback)
-
-      sinon.assert.calledOnce(mockRequest)
-      const expectedPayload = {
-        method: 'POST',
-        path: '/me/videos?fields=uri,name,upload',
-        query: { upload: { approach: 'tus', size: FILE_SIZE } }
-      }
-      sinon.assert.calledWith(mockRequest, expectedPayload)
-    })
+    sinon.assert.calledOnce(mockErrorCallback)
+    sinon.assert.calledWith(mockErrorCallback, sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Please pass in a valid file path.')))
   })
 
   describe('file exists', () => {


### PR DESCRIPTION
- Returns a Promise when `Vimeo.upload` has only `file` and `progressCallback` and/or `params` passed in.
  - ex. `vimeo.upload(file, progressCallback) or vimeo.upload(file, params, progressCallback)`
  - `progressCallback` can still be passed in to follow the upload progress
  - successfully upload will resolve with `attempt.uri` value and failed upload will be caught by an error message
- Adds a stricter check on the `file` type
- Adds tests for the new Promise implementation
- Updates the old tests when `file` is passed in as an object