### PR TITLE
Adds Promise support for `Vimeo.replace` method

### DIFF
--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -545,6 +545,9 @@ Vimeo.prototype.upload = function (
       }).catch(err => {
         reject(new Error('Unable to initiate an upload. [' + err.message + ']'))
       })
+        .catch(err => {
+          reject(new Error('Unable to initiate an upload. [' + err.message + ']'))
+        })
     })
   }
 
@@ -570,14 +573,23 @@ Vimeo.prototype.upload = function (
  *
  * https://developer.vimeo.com/api/reference/videos#create_video_version
  *
- * @param {string}    file              Path to the file you wish to upload.
- * @param {string}    videoUri          Video URI of the video file to replace.
- * @param {Object=}   params            Parameters to send when creating a new video (name,
- *                                      privacy restrictions, etc.). See the API documentation for
- *                                      supported parameters.
- * @param {Function}  completeCallback  Callback to be executed when the upload completes.
- * @param {Function}  progressCallback  Callback to be executed when upload progress is updated.
- * @param {Function}  errorCallback     Callback to be executed when the upload returns an error.
+ * .replace( file, videoUri [, params] [, completeCallback], progressCallback [, errorCallback])
+ *
+ * -  params (optional)
+ *    If an object is not provided, we will use the default params.
+ *
+ * -  completeCallback and errorCallback (optional)
+ *    If not passed in, a Promise will be returned.
+ *    Ex. vimeo.replace(file, videoUri, progressCallback) or vimeo.upload(file, videoUri, params, progressCallback)
+ *
+ * @param {string}    file                Path to the file you wish to upload.
+ * @param {string}    videoUri            Video URI of the video file to replace.
+ * @param {Object=}   [params]            (optional) Parameters to send when creating a new video (name,
+ *                                        privacy restrictions, etc.). See the API documentation for
+ *                                        supported parameters.
+ * @param {Function}  [completeCallback]  (optional) Callback to be executed when the upload completes.
+ * @param {Function}  progressCallback    Callback to be executed when upload progress is updated.
+ * @param {Function}  [errorCallback]     (optional) Callback to be executed when the upload returns an error.
  */
 Vimeo.prototype.replace = function (
   file,
@@ -597,17 +609,31 @@ Vimeo.prototype.replace = function (
     params = {}
   }
 
+  const isPromise = progressCallback === undefined && errorCallback === undefined
+
+  if (isPromise) {
+    progressCallback = completeCallback
+  }
+
   if (typeof file === 'string') {
     try {
       fileSize = fs.statSync(file).size
     } catch (e) {
+      if (isPromise) {
+        return new Promise((resolve, reject) => reject(e))
+      }
+
       return errorCallback('Unable to locate file to upload.')
     }
 
     params.file_name = path.basename(file)
   } else {
-    fileSize = file.size
-    params.file_name = file.name
+    const error = new Error('Please pass in a valid file path.')
+    if (isPromise) {
+      return new Promise((resolve, reject) => reject(error))
+    }
+
+    return errorCallback(error)
   }
 
   // Ignore any specified upload approach and size.
@@ -627,8 +653,28 @@ Vimeo.prototype.replace = function (
     query: params
   }
 
+  if (isPromise) {
+    return new Promise((resolve, reject) => {
+      this.request(options).then(attempt => {
+        attempt.uri = videoUri
+
+        _self._performTusUpload(
+          file,
+          fileSize,
+          attempt,
+          resolve,
+          progressCallback,
+          reject
+        )
+      })
+        .catch(err => {
+          reject(new Error('Unable to initiate an upload. [' + err.message + ']'))
+        })
+    })
+  }
+
   // Use JSON filtering so we only receive the data that we need to make an upload happen.
-  _self.request(options, function (err, attempt, status) {
+  _self.request(options, function (err, attempt) {
     if (err) {
       return errorCallback('Unable to initiate an upload. [' + err + ']')
     }

--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -545,9 +545,6 @@ Vimeo.prototype.upload = function (
       }).catch(err => {
         reject(new Error('Unable to initiate an upload. [' + err.message + ']'))
       })
-        .catch(err => {
-          reject(new Error('Unable to initiate an upload. [' + err.message + ']'))
-        })
     })
   }
 
@@ -576,11 +573,11 @@ Vimeo.prototype.upload = function (
  * .replace( file, videoUri [, params] [, completeCallback], progressCallback [, errorCallback])
  *
  * -  params (optional)
- *    If an object is not provided, we will use the default params.
+ *    If an object is not provided, default upload params are used.
  *
  * -  completeCallback and errorCallback (optional)
- *    If not passed in, a Promise will be returned.
- *    Ex. vimeo.replace(file, videoUri, progressCallback) or vimeo.upload(file, videoUri, params, progressCallback)
+ *    If neither passed in, a Promise will be returned.
+ *    Ex. vimeo.replace(file, videoUri, progressCallback) or vimeo.replace(file, videoUri, params, progressCallback)
  *
  * @param {string}    file                Path to the file you wish to upload.
  * @param {string}    videoUri            Video URI of the video file to replace.

--- a/test/lib/vimeo_test.js
+++ b/test/lib/vimeo_test.js
@@ -868,25 +868,14 @@ describe('Vimeo.replace', () => {
     sinon.assert.calledWith(mockErrorCallback, 'Unable to locate file to upload.')
   })
 
-  describe('file parameter is an object', () => {
-    it('request is called with the expected parameters', () => {
-      const mockRequest = sinon.fake()
-      sinon.replace(vimeo, 'request', mockRequest)
+  it('calls the errorCallback if the file parameter is an object', () => {
+    const fileObject = {
+      size: FILE_SIZE
+    }
+    vimeo.replace(fileObject, VIDEO_URI, {}, mockCompleteCallback, mockProgressCallback, mockErrorCallback)
 
-      const fileObject = {
-        size: FILE_SIZE,
-        name: 'name'
-      }
-      vimeo.replace(fileObject, VIDEO_URI, {}, mockCompleteCallback, mockProgressCallback, mockErrorCallback)
-
-      sinon.assert.calledOnce(mockRequest)
-      const expectedPayload = {
-        method: 'POST',
-        path: VIDEO_URI + '/versions?fields=upload',
-        query: { file_name: 'name', upload: { approach: 'tus', size: FILE_SIZE } }
-      }
-      sinon.assert.calledWith(mockRequest, expectedPayload)
-    })
+    sinon.assert.calledOnce(mockErrorCallback)
+    sinon.assert.calledWith(mockErrorCallback, sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Please pass in a valid file path.')))
   })
 
   describe('file exists', () => {


### PR DESCRIPTION
- Returns a Promise when Vimeo.replace has only `file`, `videoUri` and `progressCallback` and/or `params` passed in.
  - ex. `vimeo.replace(file, videoUri, progressCallback) or vimeo.upload(file, videoUri, params, progressCallback))`
- `progressCallback` can still be passed in for the upload progress
- successfully upload will resolve with `attempt.uri` value and failed upload will be caught by an error message
- Adds a stricter check on the file type
- Adds tests for the new Promise implementation
- Updates the old tests when `file` is passed in as an object