### PR TITLE
Automate package publishing on tag push

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,12 +3,12 @@ name: Publish Package
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
     tags:
       - '*.*.*'
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,23 @@
+name: Publish Package
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          # Setup .npmrc file to publish to npm
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_VIMEO_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           # Setup .npmrc file to publish to npm
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
+      - run: npm i
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_VIMEO_PUBLISH_TOKEN }}


### PR DESCRIPTION
## What this PR does

Publishing packages on npm currently requires manual access to be given to the vimeo org in npm. This is problematic from security perspective, because there is no way to automatically remove individuals once they leave Vimeo. There are also issues with maintenance, and legacy knowledge of the process.

This PR adds a GitHub workflow that automates publishing the package to the npm registry through a Vimeo/Devex-maintained npm account. The workflow is triggered when a new tag in the format `*.*.*` is pushed on `main`. 

A [tag protection rule](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules) would also be created to restrict creating/editing tags in the `*.*.*` format to admins and maintainers of the repo, thus restricting who can publish the package as well.

## Testing

Test workflow: https://github.com/vimeo/vimeo.js/pull/179/files
Test run: https://github.com/vimeo/vimeo.js/actions/runs/4451857999