### PR TITLE
removes the reference to the deprecated vimeo package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ If you’re new to Vimeo APIs, check out [Getting Started: The Basics](https://d
 ## Install the Node.js library
 To install Node.js, run the following command: 
 
-     npm install @vimeo/vimeo # for the versions after 2.3.2
-     npm install vimeo # for the old versions
+     npm install @vimeo/vimeo
 
 ## Advanced examples
 To see examples of the most common use cases of the Node.js library, visit our [Node.js Examples Library](https://developer.vimeo.com/api/libraries/examples/nodejs).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vimeo/vimeo",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "Apache-2.0",
   "description": "A Node.js library for the new Vimeo API.",
   "homepage": "https://developer.vimeo.com/",


### PR DESCRIPTION
Since we published the [older versions ](https://www.npmjs.com/package/@vimeo/vimeo?activeTab=versions)under the `@vimeo/vimeo` org, updating the installation section of the README file to remove the reference to the deprecated package. 