### PR TITLE
Update deprecated actions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -8,10 +8,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: '14.x'
           # Setup .npmrc file to publish to npm
           registry-url: 'https://registry.npmjs.org'
       - run: npm i

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 18
           # Setup .npmrc file to publish to npm
           registry-url: 'https://registry.npmjs.org'
       - run: npm i


### PR DESCRIPTION
Update deprecated actions:

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```