### PR TITLE
Fix undefined `uri` from `client.replace()`

### DIFF
--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -656,7 +656,7 @@ Vimeo.prototype.replace = function (
   if (isPromise) {
     return new Promise((resolve, reject) => {
       this.request(options).then(attempt => {
-        attempt.uri = videoUri
+        attempt.body.uri = videoUri
 
         _self._performTusUpload(
           file,


### PR DESCRIPTION
The new promise support introduced in https://github.com/vimeo/vimeo.js/pull/174 has at least one bug (the code is somewhat complex, so there may be others)

The first bug that I found was that the `uri` returned from `await client.replace(...)` is `undefined`, because `attempt.body` is passed as an argument to `_self._performTusUpload`, which then tries to access the `.uri` property on it (which does not exist for `.replace()`)

https://github.com/vimeo/vimeo.js/blob/cb62cb6dad0cd12bbbed6fbd0c215471b73f55b2/lib/vimeo.js#L656-L664

https://github.com/vimeo/vimeo.js/blob/cb62cb6dad0cd12bbbed6fbd0c215471b73f55b2/lib/vimeo.js#L707-L728

This PR changes the property which is assigned in `client.replace()` from `attempt.uri` to `attempt.body.uri`, which allows `attempt.body` to be passed to `_self._performTusUpload`, as the intention seems to be.

cc @hedyyytang 