### PR TITLE
Configure tus-js-client to not create new tus uploads

### DIFF
--- a/lib/vimeo.js
+++ b/lib/vimeo.js
@@ -719,7 +719,7 @@ Vimeo.prototype._performTusUpload = function (
   }
 
   const upload = new tus.Upload(fileUpload, {
-    endpoint: 'none',
+    uploadUrl: attempt.upload.upload_link,
     uploadSize: fileSize,
     retryDelays: [0, 1000, 3000, 5000],
     onError: errorCallback,
@@ -729,6 +729,5 @@ Vimeo.prototype._performTusUpload = function (
     }
   })
 
-  upload.url = attempt.upload.upload_link
   upload.start()
 }


### PR DESCRIPTION
Hello, I am the maintainer behind the tus-js-client library that is used to upload videos to the Vimeo API. At [Transloadit](https://transloadit.com) we are also using vimeo.js, but recently ran into the following error:

```
Error: tus: failed to create upload, caused by Error: connect ECONNREFUSED 127.0.0.1:80, originated from request (response code: 0, response text: )
    at new DetailedError (/srv/recent/9094312275/api2/node_modules/@vimeo/vimeo/node_modules/tus-js-client/lib.es5/error.js:22:116)
    at Upload._emitXhrError (/srv/recent/9094312275/api2/node_modules/@vimeo/vimeo/node_modules/tus-js-client/lib.es5/upload.js:300:23)
    at xhr.onerror (/srv/recent/9094312275/api2/node_modules/@vimeo/vimeo/node_modules/tus-js-client/lib.es5/upload.js:425:16)
    at ClientRequest.<anonymous> (/srv/recent/9094312275/api2/node_modules/@vimeo/vimeo/node_modules/tus-js-client/lib.es5/node/request.js:106:15)
    at ClientRequest.emit (node:events:518:28)
    at Socket.socketErrorListener (node:_http_client:500:9)
    at Socket.emit (node:events:518:28)
    at emitErrorNT (node:internal/streams/destroy:169:8)
    at emitErrorCloseNT (node:internal/streams/destroy:128:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  originalRequest: Request {
    _method: 'POST',
    _url: 'none',
    _headers: { 'Tus-Resumable': '1.0.0', 'Upload-Length': 156260235 },
    _resHeaders: {},
    _request: ClientRequest {
      _header: 'POST none HTTP/1.1\\r\\n' +
        'Tus-Resumable: 1.0.0\\r\n' +
        'Upload-Length: 156260235\\r\n' +
        'Host: localhost\\r\n' +
        'Connection: keep-alive\\r\n' +
        'Content-Length: 0\\r\n' +
        '\\r\n',
        [...]
    },
    _aborted: false,
    status: 0,
    onerror: [Function (anonymous)],
    onload: [Function (anonymous)],
    upload: { onprogress: [Function: noop] },
    withCredentials: false,
    responseText: ''
  },
  causingError: Error: connect ECONNREFUSED 127.0.0.1:80
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1605:16) {
    errno: -111,
    code: 'ECONNREFUSED',
    syscall: 'connect',
    address: '127.0.0.1',
    port: 80
  }
```

tus-js-client attempted to send a POST request to `http://localhost/none` in order to create the upload, which is not great. This was caused because vimeo.js sets `endpoint: 'none'` when configuring tus-js-client instead of leaving the option unset:

https://github.com/vimeo/vimeo.js/blob/ef0771e428df690aa6c37d4ed01dcf6a7dd0d8bc/lib/vimeo.js#L722

Setting the option to `'none'` means that tus-js-client thinks it can create new tus uploads at this endpoint, but this is not the case for the Vimeo API. Thus, when tus-js-client receives a 4xx or 5xx for a HEAD request, it will try to create a new upload at `'none'` which fails with the above error. This PR fixes this by removing the `endpoint` option altogether. If it is unset, tus-js-client will not try to create new uploads. Overall, this provides a more helpful error message in cases when uploads to Vimeo fail.

In addition, I updated the tus logic to use the `uploadUrl` option, which is the recommended way of passing the upload URL to tus-js-client.