### PR TITLE
Update tus-js-client to v2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "vimeo"
   ],
   "dependencies": {
-    "tus-js-client": "^1.5.1"
+    "tus-js-client": "^2.3.2"
   },
   "devDependencies": {
     "chai": "^4.x.x",


### PR DESCRIPTION
This PR upgrades the tus-js-client dependency from v1 (whose last release was ~6 years ago) to v2. v2 is not the most up-to-date version of tus-js-client but not as old as its last release (2.3.2) was about 2 years ago. You can find a list of breaking changes in the [accompanying blog post](https://tus.io/blog/2020/05/04/tus-js-client-200#breaking-changes), but all of them seem to be irrelevant for tus-js-client.

I also considered upgrading to v4, but since v3 tus-js-client does not Node < 12 anymore, which is explicitly supported by vimeo.js according to its `package.json`:

https://github.com/vimeo/vimeo.js/blob/ef0771e428df690aa6c37d4ed01dcf6a7dd0d8bc/package.json#L46-L48